### PR TITLE
Add affiliation and project info; update hero and profile contact details

### DIFF
--- a/client/src/components/demo/spline-demo.tsx
+++ b/client/src/components/demo/spline-demo.tsx
@@ -27,9 +27,21 @@ export function SplineSceneDemo() {
                   <AvatarImage src={hero.avatar} alt="Profile" />
                   <AvatarFallback>ME</AvatarFallback>
                 </Avatar>
-                <h2 className="text-3xl lg:text-4xl font-serif font-medium text-neutral-900 tracking-tight leading-[1]">
-                  {hero.name}
-                </h2>
+                <div className="flex flex-col gap-2">
+                  <h2 className="text-3xl lg:text-4xl font-serif font-medium text-neutral-900 tracking-tight leading-[1]">
+                    {hero.name}
+                  </h2>
+                  <p className="text-sm lg:text-base font-serif text-amber-700 tracking-wide">
+                    {hero.role}
+                  </p>
+                  <p className="text-sm lg:text-base font-serif text-neutral-700">
+                    {hero.affiliation}
+                  </p>
+                </div>
+              </div>
+
+              <div className="rounded-2xl border border-amber-200/70 bg-amber-50/50 px-4 py-3 text-sm lg:text-base font-serif text-neutral-800 shadow-sm max-w-lg">
+                {hero.project}
               </div>
 
               {/* Bio Text */}

--- a/client/src/components/hero.tsx
+++ b/client/src/components/hero.tsx
@@ -12,10 +12,10 @@ export function Hero() {
           className="max-w-3xl"
         >
           <h1 className="font-bold tracking-tight text-[clamp(2.5rem,5vw,3.25rem)] text-neutral-900 dark:text-white mb-6">
-            Ming Ma <span className="text-amber-600">PhD Candidate</span>
+            Ming Ma <span className="text-amber-600">Postdoctoral Researcher</span>
           </h1>
           <p className="text-lg leading-relaxed text-neutral-700 dark:text-neutral-300 max-w-prose">
-            Researching <span className="font-medium text-amber-600">authoritarian governance</span>, <span className="font-medium text-amber-600">AI adoption</span>, and <span className="font-medium text-amber-600">political communication</span>. Combining computational methods, media analysis, and institutional perspectives.
+            Postdoctoral researcher at <span className="font-medium text-amber-600">Leibniz Universität Hannover</span>, working on the ERC project <span className="font-medium text-amber-600">BiASE-AI</span>. Researching AI adoption in public services, computational social science, and comparative politics.
           </p>
           <div className="flex flex-wrap gap-2 mt-6">
             {['Authoritarian Politics','AI & Governance','Media Narratives','Computational Methods'].map(tag => (

--- a/client/src/data/content.ts
+++ b/client/src/data/content.ts
@@ -1,13 +1,16 @@
 export const hero = {
     name: "Ming Ma",
     role: "Postdoctoral Researcher",
+    affiliation: "Leibniz Universität Hannover",
+    project: "ERC project BiASE-AI — Biases in Administrative Service Encounters: Transitioning from Human to Artificial Intelligence",
     bio: [
-        "Hi, Welcome! I am a postdoctoral researcher at Zeppelin University.",
+        "Hi, Welcome! I am a postdoctoral researcher at Leibniz Universität Hannover.",
+        "I work on the ERC project BiASE-AI (Biases in Administrative Service Encounters: Transitioning from Human to Artificial Intelligence).",
         "I study AI and public service transformation, computational social science and comparative politics.",
         "I am particularly interested in how emerging technology both shapes and is shaped by the dynamics of power, wealth and knowledge distribution.",
         "My work has been published in peer-reviewed journals, including Perspectives on Politics, Political Research Quarterly, Journal of Contemporary China, China Review, China Perspectives, among other journals."
     ],
-    email: "ming.ma@zu.de",
+    email: "m.ma@ipw.uni-hannover.de",
     socials: [
         {
             icon: "Twitter",
@@ -16,7 +19,7 @@ export const hero = {
         },
         {
             icon: "Mail",
-            link: "mailto:ming.ma@zu.de",
+            link: "mailto:m.ma@ipw.uni-hannover.de",
             label: "Email Ming Ma"
         }
     ],
@@ -47,6 +50,11 @@ export const updates = [
 ];
 
 export const projects = [
+    {
+        title: "BiASE-AI: Biases in Administrative Service Encounters",
+        desc: "As a postdoctoral researcher at Leibniz Universität Hannover, I contribute to the ERC project BiASE-AI, which examines how administrative service encounters change as public services transition from human decision-making to artificial intelligence.",
+        img: "/project-3.jpg"
+    },
     {
         title: "SCRIPTS: Reinterpreting the alternative script? War in Ukraine, state-sponsored narratives of block building in authoritarian countries and their public perception",
         desc: `The project analyzes the construction of 'alternative' narratives by authoritarian governments competing against the liberal script and the way these narratives are perceived, reinterpr[...]`


### PR DESCRIPTION
### Motivation

- Surface current position, affiliation and ERC project details on the site and update contact information to the new institutional email.

### Description

- Update the hero header copy to reflect the current position as "Postdoctoral Researcher" and a revised intro paragraph referencing Leibniz Universität Hannover and the BiASE-AI project in `client/src/components/hero.tsx`.
- Expand the `hero` data in `client/src/data/content.ts` with `affiliation`, `project`, updated `bio` entries, and replace the email and mailto link with the new institutional address; also add the BiASE-AI project entry to `projects`.
- Modify the Spline demo component in `client/src/components/demo/spline-demo.tsx` to show role, affiliation and project information alongside the avatar and reorganize layout for the added fields.

### Testing

- Ran the project's build/typecheck with `pnpm build` and the test suite with `pnpm test`, and both completed successfully.
- Ran linting with `pnpm lint`, which reported no new issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2916f9f2688323849caa69a03f28c1)